### PR TITLE
Add quick add meal option

### DIFF
--- a/src/Dialogs/CalendarQuickAddDialog.jsx
+++ b/src/Dialogs/CalendarQuickAddDialog.jsx
@@ -1,0 +1,66 @@
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Grow, TextField } from "@mui/material";
+import { forwardRef, useEffect, useState } from "react";
+
+const Transition = forwardRef(function Transition(props, ref) {
+    return <Grow ref={ref} {...props} />;
+});
+
+const CalendarQuickAddDialog = ({ open, onClose, onSave }) => {
+    const [name, setName] = useState('');
+    const [calories, setCalories] = useState('');
+
+    useEffect(() => {
+        if(open){
+            setName('');
+            setCalories('');
+        }
+    }, [open]);
+
+    const handleSave = () => {
+        const data = {
+            name: name,
+            calories: parseFloat(calories)
+        };
+        console.log(data);
+        if(onSave) onSave(data);
+        if(onClose) onClose();
+    };
+
+    return (
+        <Dialog
+            open={open}
+            TransitionComponent={Transition}
+            keepMounted
+            onClose={onClose}
+            fullWidth
+            maxWidth={'xs'}
+        >
+            <DialogTitle>Szybkie dodawanie</DialogTitle>
+            <DialogContent>
+                <TextField
+                    autoFocus
+                    variant={'standard'}
+                    label={'Nazwa posiłku'}
+                    fullWidth
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                />
+                <TextField
+                    style={{marginTop: 20}}
+                    variant={'standard'}
+                    label={'Kalorie'}
+                    type={'number'}
+                    fullWidth
+                    value={calories}
+                    onChange={(e) => setCalories(e.target.value)}
+                />
+            </DialogContent>
+            <DialogActions>
+                <Button color={'warning'} onClick={onClose}>Anuluj</Button>
+                <Button onClick={handleSave}>Zapisz</Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default CalendarQuickAddDialog;

--- a/src/Dialogs/SourceSelectDialog.jsx
+++ b/src/Dialogs/SourceSelectDialog.jsx
@@ -14,6 +14,7 @@ import {Icon} from "@iconify/react/offline";
 import receiptText from "@iconify/icons-mdi/receipt-text";
 import burgerIcon from "@iconify/icons-mdi/burger";
 import fruitWatermelon from "@iconify/icons-mdi/fruit-watermelon";
+import plusIcon from "@iconify/icons-mdi/plus";
 
 const Transition = forwardRef(function Transition(props, ref) {
     return <Grow /*direction="down"*/ ref={ref} {...props} />;
@@ -116,12 +117,19 @@ const SourceSelectDialog = (
                         title="Przepisy"
                         icon={receiptText}
                     />
-                    <SourceSelector
+                <SourceSelector
                         onClick={() => onSelect('fastfood')}
                         bgColor={'#ffde87'}
                         hoverBg={'#c7ac67'}
                         title="Fast Food"
                         icon={burgerIcon}
+                    />
+                    <SourceSelector
+                        onClick={() => onSelect('quick')}
+                        bgColor={'#8bc34a'}
+                        hoverBg={'#6f9c39'}
+                        title="Szybkie dodawanie"
+                        icon={plusIcon}
                     />
                     <SourceSelector
                         onClick={() => onSelect('source')}

--- a/src/Views/Dashboard/CalendarView.jsx
+++ b/src/Views/Dashboard/CalendarView.jsx
@@ -38,6 +38,7 @@ import CalendarEntryFromFastFoodCEDialog from "@/Dialogs/CalendarEntryFromFastFo
 import CalendarEntryFastFoodAPI from "@/API/CalendarEntryFastFoodAPI";
 import FastFoodEntryViewDialog from "@/Dialogs/FastFoodEntryViewDialog";
 import TrainingsAPI from "@/API/TrainingsAPI";
+import CalendarQuickAddDialog from "@/Dialogs/CalendarQuickAddDialog";
 
 const DateContainer = styled.div`
   
@@ -419,6 +420,10 @@ const CalendarView = () => {
             open={selectedSource === 'recipe'}
             onClose={handleCloseSourceInputDialog}
             onSelect={selectRecipe}
+        />
+        <CalendarQuickAddDialog
+            open={selectedSource === 'quick'}
+            onClose={handleCloseSourceInputDialog}
         />
         <div style={!isMobile && {
             display: 'flex',


### PR DESCRIPTION
## Summary
- create `CalendarQuickAddDialog` for quick meal input
- extend `SourceSelectDialog` with 'Szybkie dodawanie'
- wire quick add dialog into Calendar view

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6859459c04ac832388f71e0f8e608f34